### PR TITLE
Remove MONODIFF variable again

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This plugin will assist you in triggering pipelines by watching folders in your 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - heap/monorepo-diff#v1.3.4:
+      - heap/monorepo-diff#v1.3.6:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -27,7 +27,7 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - heap/monorepo-diff#v1.3.4:
+      - heap/monorepo-diff#v1.3.6:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           watch:

--- a/hooks/command
+++ b/hooks/command
@@ -32,5 +32,5 @@ else
     NO_INTERPOLATION="--no-interpolation"
   fi
 
-  echo "$output" | MONODIFF="${diff}" buildkite-agent pipeline upload ${NO_INTERPOLATION}
+  echo "$output" | buildkite-agent pipeline upload ${NO_INTERPOLATION}
 fi


### PR DESCRIPTION
It causes errors when the diff is too large; the final command performs an expansion of `${diff}` into an environment variable for the `buildkite-agent upload`, which hits a maximum command length limitation.

So, until we get failures on line 16 instead, this is probably sufficient.

(Now I just need to make a change to `heap/heap` to pick up v1.3.6 of this plugin and remove the dependency on MONODIFF)